### PR TITLE
Removed the double "Kernel Exploitation" header

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,16 +30,14 @@ This is a living document to host and contain links and resources for online war
 
 <!-- ------------------------------------------------------- -->
 
-### Kernel Exploitation
-
-#### Tools
-
-<!-- ------------------------------------------------------- -->
-
 #### Kernel Exploitation
   * [linux-kernel-exploitation](https://github.com/xairy/linux-kernel-exploitation)
   * [Writing Kernel Drivers](http://freesoftwaremagazine.com/articles/drivers_linux/)
   * [willsroot.io](https://www.willsroot.io/)
+
+#### Tools
+
+<!-- ------------------------------------------------------- -->
 
 #### Browser Exploitation
   * [faraz.faith](https://faraz.faith/)


### PR DESCRIPTION
The "Kernel Exploitation" was listed twice and just removed one of it so it matches the Browser Exploitation style.